### PR TITLE
Allow lookup constraints per back-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@
 
 - If we cannot parse JSON as json, do something nasty to try if the value is a
   boolean
+
+### 2.1.0
+
+- Host/domain constraints can now be defined per hierarchy file instead of being global only

--- a/hiera-mysql-json-backend-puppetserver.gemspec
+++ b/hiera-mysql-json-backend-puppetserver.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "hiera-mysql-json-backend-jruby"
-  gem.version       = "2.0.0"
+  gem.version       = "2.1.0"
   gem.authors       = ["Hostnet"]
   gem.email         = ["opensource@hostnet.nl"]
   gem.description   = %q{Alternative MySQL backend with json support for hiera}

--- a/hiera-mysql-json-backend.gemspec
+++ b/hiera-mysql-json-backend.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "hiera-mysql-json-backend"
-  gem.version       = "2.0.0"
+  gem.version       = "2.1.0"
   gem.authors       = ["Hostnet"]
   gem.email         = ["opensource@hostnet.nl"]
   gem.description   = %q{Alternative MySQL backend with json support for hiera}

--- a/lib/hiera/backend/mysql_json_backend.rb
+++ b/lib/hiera/backend/mysql_json_backend.rb
@@ -66,6 +66,9 @@ class Hiera
           mysql_pass = mysql_config.fetch(:pass, nil) || Config[:mysql_json][:pass]
           mysql_port = mysql_config.fetch(:port, nil) || Config[:mysql_json][:port] || '3306'
           mysql_database = mysql_config.fetch(:database, nil) || Config[:mysql_json][:database]
+          lookup_constraints = data.fetch(:only_for, nil) || Config[:mysql_json][:only_for] || {}
+
+          next unless should_lookup?(lookup_constraints, scope)
 
           connection_hash = {
             host:      mysql_host,


### PR DESCRIPTION
It's currently possible to override database connection settings per back-end. Expanding this functionality towards the only_for configuration option that is used to limit lookups to specific hosts/domains/etc.
Decided to keep the original point in code where this constraint is checked for, so there's a possibility to return early, and prevent additional files being opened.