### PR TITLE
Start caching mysql results

### DIFF
--- a/hiera-mysql-json-backend-puppetserver.gemspec
+++ b/hiera-mysql-json-backend-puppetserver.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "hiera-mysql-json-backend-jruby"
-  gem.version       = "2.2.0"
+  gem.version       = "2.2.1"
   gem.authors       = ["Hostnet"]
   gem.email         = ["opensource@hostnet.nl"]
   gem.description   = %q{Alternative MySQL backend with json support for hiera}

--- a/hiera-mysql-json-backend.gemspec
+++ b/hiera-mysql-json-backend.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "hiera-mysql-json-backend"
-  gem.version       = "2.2.0"
+  gem.version       = "2.2.1"
   gem.authors       = ["Hostnet"]
   gem.email         = ["opensource@hostnet.nl"]
   gem.description   = %q{Alternative MySQL backend with json support for hiera}


### PR DESCRIPTION
We see multiple mysql queries being executed per key, per file. Caching results to prevent performance loss.